### PR TITLE
add convert_blessed=>1 to to_json to allow objects to be stored

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -9,6 +9,7 @@ t/lib/Test/Custom.pm
 t/lib/Test/Custom/Result/Custom.pm
 t/lib/Test/Schema.pm
 t/lib/Test/Schema/Result/Session.pm
+t/lib/Test/WibbleObject.pm
 t/manifest.t
 t/pod.t
 t/pod-coverage.t

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -27,6 +27,7 @@ my %WriteMakefileArgs = (
     "Scalar::Util" => 0,
   },
   "TEST_REQUIRES" => {
+    "Test::Exception" => 0,
     "Test::More" => "0.63",
     "DBICx::TestDatabase" => 0,
     "DBIx::Class::TimeStamp" => 0,

--- a/lib/Dancer/Session/DBIC.pm
+++ b/lib/Dancer/Session/DBIC.pm
@@ -241,7 +241,7 @@ sub _serialize {
 
     # A session is by definition ephemeral - Store it compactly
     # This is the Dancer function, not from JSON.pm
-    return to_json({%$self}, { pretty => 0 });
+    return to_json({%$self}, { pretty => 0, convert_blessed => 1 });
 }
 
 

--- a/t/lib/Test/WibbleObject.pm
+++ b/t/lib/Test/WibbleObject.pm
@@ -1,0 +1,23 @@
+package Test::WibbleObject;
+use strict;
+use warnings;
+
+sub new {
+    my $self = {};
+    $self->{name} = undef;
+    bless($self);
+    return $self;
+}
+
+sub name {
+    my $self = shift;
+    if (@_) { $self->{name} = shift };
+    return $self->{name};
+}
+
+sub TO_JSON {
+    my $self = shift;
+    return { name => $self->name };
+}
+
+1;

--- a/t/schema.t
+++ b/t/schema.t
@@ -3,6 +3,7 @@ use warnings;
 
 use utf8;
 use Test::More;
+use Test::Exception;
 
 use Dancer::Session::DBIC;
 use Dancer qw(:syntax :tests);
@@ -11,6 +12,7 @@ use File::Spec;
 use lib File::Spec->catdir( 't', 'lib' );
 
 use DBICx::TestDatabase;
+use Test::WibbleObject;
 
 test_session_schema('Test::Schema');
 test_session_schema('Test::Custom', {resultset => 'Custom',
@@ -62,6 +64,21 @@ sub test_session_schema {
 
     ok ($camel eq 'ラクダ', 'Testing utf-8 characters in the session.')
         || diag "Return values: ", $camel;
+
+
+    # to_json allows objects
+    my ( $wibble, $data );
+
+    lives_ok( sub { $wibble = Test::WibbleObject->new() },
+        "create Test::WibbleObject" );
+    isa_ok( $wibble, "Test::WibbleObject" );
+    lives_ok( sub { $wibble->name("Foo")}, "wibble name set to Foo" );
+
+    lives_ok( sub { session wibble => $wibble }, "put wibble in session" );
+
+    lives_ok( sub { $data = session('wibble') }, "get wibble out of session" );
+
+    is_deeply( $data, { name => "Foo" }, "returned data is good" );
 }
 
 done_testing;


### PR DESCRIPTION
User still has to build some kind of unfreeze but at least this allows objects that include TO_JSON to be stored instead of throwing an exception. Tests also added.